### PR TITLE
Fix OAuthException Class

### DIFF
--- a/lti/lib/OAuth.php
+++ b/lti/lib/OAuth.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
Throws an error if the class already exists. Looked around and this seemed to be the appropriate fix.
